### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 424 Simulation
+# PERRINN 424 Simulation
 Simulation of the PERRINN 424 electric hypercar in Unity using Vehicle Physics Pro.
 
 [More information on 424 Simulation](https://discover.perrinn.com/424/424-unity-simulation)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Project 424
+# 424 Simulation
 Simulation of the PERRINN 424 electric hypercar in Unity using Vehicle Physics Pro.
 
-[More information on Project 424](https://discover.perrinn.com/project-424/424-unity-simulation)
+[More information on 424 Simulation](https://discover.perrinn.com/424/424-unity-simulation)
 
 ## Videos
 


### PR DESCRIPTION
I have updated the address of the link to the page about 424 simulation on Discover website. The previous one was obsolete as "Project 424" has become "424" in the URL path of the page. I have also updated the text to suppress any mention of "Project 424" as we call it "424" or "PERRINN 424" now.